### PR TITLE
Revert "Move trufflehogs checks to its own branch"

### DIFF
--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -1,7 +1,8 @@
-name: WIP. Please Ignore this failure. Leaked Secrets Scan Test
+name: Leaked Secrets Scan Test
 on:
+  pull_request:
   push:
-    branches: [ "trufflehog" ]
+    branches: [ "master" ]
 jobs:
   TruffleHog:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This reverts commit afcfd48afc9e053e405388db837e53891f738a66 as trufflesecurity/trufflehog/issues/666 is already fixed

[type description here, PLEASE, REMOVE THIS LINE, PLACEHOLDER, BEFORE SUBMITTING THIS PULL REQUEST]

- Related ticket: https://progress.opensuse.org/issues/xyz
- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/xyz
- Verification run: openqa.mypersonalinstance.de/tests/xyz#step/module/x
